### PR TITLE
Expand OreType, RockType, and add GemstoneType

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
     - `Resources/` — Default YAML configs (`outpost.yaml`, `creatures.yaml`, `items.yaml`)
   - `Sources/OutpostWorldGen/` — World generation module (Layer 2 — depends on OutpostCore)
     - `Terrain/` — 7-stage procedural terrain pipeline (13 files)
-    - `Terrain/Geology/` — Geological subsystem: `TectonicSimulator`, `StrataGenerator`, `GeologyGenerator`, `RockType`, `GeologicalColumn`
+    - `Terrain/Geology/` — Geological subsystem: `TectonicSimulator`, `StrataGenerator`, `GeologyGenerator`, `RockType`, `GeologicalColumn`, `OreType`, `GemstoneType`
     - `WorldGenerator.swift` — World generator with history simulation
     - `History.swift` — Historical events, figures, civilizations
   - `Sources/OutpostRuntime/` — Simulation engine and manager systems (Layer 3 — depends on OutpostCore + OutpostWorldGen)

--- a/Outpost/Outpost/SpriteKit/TextureManager.swift
+++ b/Outpost/Outpost/SpriteKit/TextureManager.swift
@@ -141,6 +141,32 @@ final class TextureManager {
             .gabbro: PlatformColor(red: 0.3, green: 0.3, blue: 0.32, alpha: 1),
             .quartzite: PlatformColor(red: 0.82, green: 0.78, blue: 0.72, alpha: 1),
             .schist: PlatformColor(red: 0.45, green: 0.48, blue: 0.42, alpha: 1),
+            // Expanded real geology
+            .chalk: PlatformColor(red: 0.92, green: 0.9, blue: 0.85, alpha: 1),
+            .mudstone: PlatformColor(red: 0.52, green: 0.44, blue: 0.36, alpha: 1),
+            .siltstone: PlatformColor(red: 0.58, green: 0.52, blue: 0.42, alpha: 1),
+            .travertine: PlatformColor(red: 0.88, green: 0.82, blue: 0.7, alpha: 1),
+            .rhyolite: PlatformColor(red: 0.65, green: 0.55, blue: 0.5, alpha: 1),
+            .tuff: PlatformColor(red: 0.55, green: 0.5, blue: 0.42, alpha: 1),
+            .pumice: PlatformColor(red: 0.78, green: 0.76, blue: 0.72, alpha: 1),
+            .pegmatite: PlatformColor(red: 0.7, green: 0.65, blue: 0.62, alpha: 1),
+            .serpentinite: PlatformColor(red: 0.3, green: 0.45, blue: 0.3, alpha: 1),
+            .soapstone: PlatformColor(red: 0.65, green: 0.68, blue: 0.62, alpha: 1),
+            .phyllite: PlatformColor(red: 0.48, green: 0.5, blue: 0.46, alpha: 1),
+            .migmatite: PlatformColor(red: 0.58, green: 0.52, blue: 0.55, alpha: 1),
+            // Expanded fantasy geology
+            .deepslate: PlatformColor(red: 0.18, green: 0.18, blue: 0.22, alpha: 1),
+            .glowstone: PlatformColor(red: 0.7, green: 0.85, blue: 0.6, alpha: 1),
+            .shadowrock: PlatformColor(red: 0.2, green: 0.15, blue: 0.25, alpha: 1),
+            .crystalrock: PlatformColor(red: 0.65, green: 0.75, blue: 0.85, alpha: 1),
+            .bloodstone: PlatformColor(red: 0.55, green: 0.15, blue: 0.15, alpha: 1),
+            .voidrock: PlatformColor(red: 0.12, green: 0.08, blue: 0.18, alpha: 1),
+            .moonstone: PlatformColor(red: 0.7, green: 0.72, blue: 0.85, alpha: 1),
+            .sunrock: PlatformColor(red: 0.85, green: 0.7, blue: 0.35, alpha: 1),
+            .dragonrock: PlatformColor(red: 0.5, green: 0.2, blue: 0.1, alpha: 1),
+            .runestone: PlatformColor(red: 0.45, green: 0.5, blue: 0.6, alpha: 1),
+            .aetherstone: PlatformColor(red: 0.6, green: 0.7, blue: 0.8, alpha: 1),
+            .livingrock: PlatformColor(red: 0.4, green: 0.55, blue: 0.35, alpha: 1),
         ]
 
         let size = CGSize(width: 32, height: 32)

--- a/OutpostKit/Sources/OutpostCore/Core/World.swift
+++ b/OutpostKit/Sources/OutpostCore/Core/World.swift
@@ -556,12 +556,20 @@ public final class World: Sendable {
         var resultItem: Item?
         switch terrain {
         case .wall, .stone, .sandstone, .limestone, .granite,
-             .basalt, .diorite, .gabbro, .slate, .shale, .schist, .obsidian:
+             .basalt, .diorite, .gabbro, .slate, .shale, .schist, .obsidian,
+             .chalk, .mudstone, .siltstone, .tuff, .pumice,
+             .serpentinite, .soapstone, .phyllite,
+             .deepslate, .shadowrock, .voidrock, .dragonrock, .livingrock:
             tile.terrain = .stoneFloor
             resultItem = Item.create(type: .stone, at: position, quality: .standard)
-        case .marble, .quartzite:
+        case .marble, .quartzite,
+             .pegmatite, .migmatite, .travertine,
+             .crystalrock, .moonstone, .sunrock, .aetherstone:
             tile.terrain = .stoneFloor
             resultItem = Item.create(type: .stone, at: position, quality: .finelyCrafted)
+        case .glowstone, .bloodstone, .runestone, .rhyolite:
+            tile.terrain = .stoneFloor
+            resultItem = Item.create(type: .stone, at: position, quality: .masterwork)
         case .ore:
             tile.terrain = .stoneFloor
             resultItem = Item.create(type: .ore, at: position, quality: .standard)

--- a/OutpostKit/Sources/OutpostCore/Types/TerrainType.swift
+++ b/OutpostKit/Sources/OutpostCore/Types/TerrainType.swift
@@ -51,6 +51,34 @@ public enum TerrainType: String, CaseIterable, Sendable {
     case quartzite
     case schist
 
+    // Expanded geological rock types — real
+    case chalk
+    case mudstone
+    case siltstone
+    case travertine
+    case rhyolite
+    case tuff
+    case pumice
+    case pegmatite
+    case serpentinite
+    case soapstone
+    case phyllite
+    case migmatite
+
+    // Expanded geological rock types — fantasy
+    case deepslate
+    case glowstone
+    case shadowrock
+    case crystalrock
+    case bloodstone
+    case voidrock
+    case moonstone
+    case sunrock
+    case dragonrock
+    case runestone
+    case aetherstone
+    case livingrock
+
     // Constructed terrain
     case woodenFloor
     case stoneFloor
@@ -75,7 +103,13 @@ public enum TerrainType: String, CaseIterable, Sendable {
              .deepWater, .ice, .coniferTree, .palmTree, .deadTree,
              .cactus, .reeds, .marsh, .obsidian, .lava,
              .sandstone, .limestone, .granite,
-             .basalt, .marble, .slate, .shale, .diorite, .gabbro, .quartzite, .schist:
+             .basalt, .marble, .slate, .shale, .diorite, .gabbro, .quartzite, .schist,
+             .chalk, .mudstone, .siltstone, .travertine,
+             .rhyolite, .tuff, .pumice, .pegmatite,
+             .serpentinite, .soapstone, .phyllite, .migmatite,
+             .deepslate, .glowstone, .shadowrock, .crystalrock,
+             .bloodstone, .voidrock, .moonstone, .sunrock,
+             .dragonrock, .runestone, .aetherstone, .livingrock:
             return false
         }
     }
@@ -104,7 +138,13 @@ public enum TerrainType: String, CaseIterable, Sendable {
     public var isMinable: Bool {
         switch self {
         case .wall, .stone, .ore, .sandstone, .limestone, .granite, .obsidian,
-             .basalt, .marble, .slate, .shale, .diorite, .gabbro, .quartzite, .schist:
+             .basalt, .marble, .slate, .shale, .diorite, .gabbro, .quartzite, .schist,
+             .chalk, .mudstone, .siltstone, .travertine,
+             .rhyolite, .tuff, .pumice, .pegmatite,
+             .serpentinite, .soapstone, .phyllite, .migmatite,
+             .deepslate, .glowstone, .shadowrock, .crystalrock,
+             .bloodstone, .voidrock, .moonstone, .sunrock,
+             .dragonrock, .runestone, .aetherstone, .livingrock:
             return true
         default:
             return false
@@ -209,6 +249,33 @@ public enum TerrainType: String, CaseIterable, Sendable {
         case .gabbro: return "▰"
         case .quartzite: return "◈"
         case .schist: return "◆"
+        // Expanded real geology
+        case .chalk: return "▭"
+        case .mudstone: return "▯"
+        case .siltstone: return "▱"
+        case .travertine: return "▲"
+        case .rhyolite: return "▴"
+        case .tuff: return "▵"
+        case .pumice: return "▷"
+        case .pegmatite: return "▸"
+        case .serpentinite: return "▹"
+        case .soapstone: return "▻"
+        case .phyllite: return "▼"
+        case .migmatite: return "▽"
+        // Expanded fantasy geology
+        case .deepslate: return "◉"
+        case .glowstone: return "◎"
+        case .shadowrock: return "●"
+        case .crystalrock: return "◐"
+        case .bloodstone: return "◑"
+        case .voidrock: return "◒"
+        case .moonstone: return "◓"
+        case .sunrock: return "◔"
+        case .dragonrock: return "◕"
+        case .runestone: return "◖"
+        case .aetherstone: return "◗"
+        case .livingrock: return "◘"
+        // Constructed
         case .woodenFloor: return "="
         case .stoneFloor: return "+"
         case .constructedWall: return "H"

--- a/OutpostKit/Sources/OutpostWorldGen/Terrain/DetailPass.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Terrain/DetailPass.swift
@@ -158,6 +158,14 @@ struct DetailPass: Sendable {
             let oreType = compatible[rng.nextInt(in: 0...(compatible.count - 1))]
             cell.oreType = oreType
             cell.oreRichness = richness
+
+            // If ore is gemstone, pick a specific gemstone type from rock compatibility
+            if oreType == .gemstone {
+                let gems = midRock.compatibleGemstones
+                if !gems.isEmpty {
+                    cell.gemstoneType = gems[rng.nextInt(in: 0...(gems.count - 1))]
+                }
+            }
             return
         }
 

--- a/OutpostKit/Sources/OutpostWorldGen/Terrain/Geology/GemstoneType.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Terrain/Geology/GemstoneType.swift
@@ -1,0 +1,107 @@
+// MARK: - Gemstone Type
+// Specific gemstone varieties replacing the catch-all .gemstone OreType
+
+/// Types of gemstones that can be found in ore deposits
+enum GemstoneType: String, CaseIterable, Sendable {
+    case diamond
+    case ruby
+    case emerald
+    case sapphire
+    case amethyst
+    case topaz
+    case opal
+    case garnet
+    case jade
+    case onyx
+    case turquoise
+    case lapis
+
+    /// Rarity factor (0-1, lower = rarer)
+    var rarity: Float {
+        switch self {
+        case .diamond: return 0.05
+        case .ruby: return 0.08
+        case .emerald: return 0.08
+        case .sapphire: return 0.10
+        case .opal: return 0.12
+        case .topaz: return 0.15
+        case .jade: return 0.15
+        case .lapis: return 0.15
+        case .turquoise: return 0.18
+        case .amethyst: return 0.20
+        case .onyx: return 0.20
+        case .garnet: return 0.25
+        }
+    }
+
+    /// Base trade value
+    var value: Int {
+        switch self {
+        case .diamond: return 500
+        case .ruby: return 350
+        case .emerald: return 350
+        case .sapphire: return 300
+        case .opal: return 250
+        case .topaz: return 200
+        case .jade: return 200
+        case .lapis: return 200
+        case .turquoise: return 175
+        case .amethyst: return 150
+        case .onyx: return 150
+        case .garnet: return 100
+        }
+    }
+}
+
+// MARK: - RockType Gemstone Compatibility
+
+extension RockType {
+    /// Gemstone types that can appear within this rock
+    var compatibleGemstones: [GemstoneType] {
+        switch self {
+        // Sedimentary: common gems
+        case .sandstone, .limestone, .shale, .conglomerate,
+             .chalk, .mudstone, .siltstone, .travertine:
+            return [.amethyst, .garnet, .onyx]
+
+        // Igneous extrusive
+        case .basalt, .andesite, .rhyolite, .tuff, .pumice:
+            return [.opal, .garnet, .topaz]
+
+        // Igneous intrusive — gemstone-rich
+        case .granite, .diorite, .gabbro:
+            return [.diamond, .emerald, .topaz, .ruby, .sapphire]
+
+        // Pegmatite — extra gemstone-rich
+        case .pegmatite:
+            return [.diamond, .emerald, .topaz, .opal]
+
+        // Metamorphic
+        case .slate, .schist, .marble, .quartzite, .gneiss,
+             .serpentinite, .soapstone, .phyllite, .migmatite:
+            return [.ruby, .emerald, .sapphire, .jade, .lapis]
+
+        // Volcanic glass
+        case .obsidian:
+            return [.onyx, .opal]
+
+        // Fantasy rocks — magical gems
+        case .deepslate, .voidrock, .dragonrock:
+            return [.diamond, .ruby, .sapphire]
+        case .glowstone, .crystalrock, .aetherstone:
+            return [.opal, .topaz, .amethyst]
+        case .shadowrock:
+            return [.onyx, .lapis]
+        case .bloodstone:
+            return [.ruby, .garnet]
+        case .moonstone:
+            return [.sapphire, .opal, .diamond]
+        case .sunrock:
+            return [.topaz, .ruby, .garnet]
+        case .runestone:
+            return [.lapis, .amethyst, .sapphire]
+        case .livingrock:
+            return [.emerald, .jade, .turquoise]
+        }
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Terrain/Geology/OreType.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Terrain/Geology/OreType.swift
@@ -2,6 +2,7 @@
 
 /// Types of mineable ore deposits
 enum OreType: String, CaseIterable, Sendable {
+    // Original ores
     case iron
     case copper
     case tin
@@ -9,4 +10,32 @@ enum OreType: String, CaseIterable, Sendable {
     case silver
     case coal
     case gemstone
+
+    // Real geology ores
+    case lead
+    case zinc
+    case nickel
+    case platinum
+    case chromium
+    case tungsten
+    case cobalt
+    case mercury
+    case sulfur
+    case saltpeter
+    case bauxite
+    case bismuth
+
+    // Fantasy ores
+    case mithril
+    case adamantine
+    case orichalcum
+    case starmetal
+    case moonsilver
+    case sunstone
+    case darksteel
+    case bloodiron
+    case etherealite
+    case runegold
+    case voidstone
+    case dragonite
 }

--- a/OutpostKit/Sources/OutpostWorldGen/Terrain/Geology/RockType.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Terrain/Geology/RockType.swift
@@ -10,15 +10,23 @@ enum RockType: String, CaseIterable, Sendable {
     case limestone
     case shale
     case conglomerate
+    case chalk
+    case mudstone
+    case siltstone
+    case travertine
 
     // Igneous extrusive
     case basalt
     case andesite
+    case rhyolite
+    case tuff
+    case pumice
 
     // Igneous intrusive
     case granite
     case diorite
     case gabbro
+    case pegmatite
 
     // Metamorphic
     case slate
@@ -26,9 +34,29 @@ enum RockType: String, CaseIterable, Sendable {
     case marble
     case quartzite
     case gneiss
+    case serpentinite
+    case soapstone
+    case phyllite
+    case migmatite
 
     // Volcanic glass
     case obsidian
+
+    // Fantasy — deep crust
+    case deepslate
+
+    // Fantasy — magical
+    case glowstone
+    case shadowrock
+    case crystalrock
+    case bloodstone
+    case voidrock
+    case moonstone
+    case sunrock
+    case dragonrock
+    case runestone
+    case aetherstone
+    case livingrock
 
     /// Maps to the corresponding TerrainType for tile rendering
     var terrainType: TerrainType {
@@ -37,57 +65,169 @@ enum RockType: String, CaseIterable, Sendable {
         case .limestone: return .limestone
         case .shale: return .shale
         case .conglomerate: return .sandstone
+        case .chalk: return .chalk
+        case .mudstone: return .mudstone
+        case .siltstone: return .siltstone
+        case .travertine: return .travertine
         case .basalt: return .basalt
         case .andesite: return .basalt
+        case .rhyolite: return .rhyolite
+        case .tuff: return .tuff
+        case .pumice: return .pumice
         case .granite: return .granite
         case .diorite: return .diorite
         case .gabbro: return .gabbro
+        case .pegmatite: return .pegmatite
         case .slate: return .slate
         case .schist: return .schist
         case .marble: return .marble
         case .quartzite: return .quartzite
         case .gneiss: return .granite
+        case .serpentinite: return .serpentinite
+        case .soapstone: return .soapstone
+        case .phyllite: return .phyllite
+        case .migmatite: return .migmatite
         case .obsidian: return .obsidian
+        case .deepslate: return .deepslate
+        case .glowstone: return .glowstone
+        case .shadowrock: return .shadowrock
+        case .crystalrock: return .crystalrock
+        case .bloodstone: return .bloodstone
+        case .voidrock: return .voidrock
+        case .moonstone: return .moonstone
+        case .sunrock: return .sunrock
+        case .dragonrock: return .dragonrock
+        case .runestone: return .runestone
+        case .aetherstone: return .aetherstone
+        case .livingrock: return .livingrock
         }
     }
 
     /// Rock hardness (0-1), affects mining speed
     var hardness: Float {
         switch self {
+        case .chalk: return 0.15
+        case .mudstone: return 0.18
         case .shale: return 0.2
+        case .siltstone: return 0.22
+        case .pumice: return 0.25
+        case .travertine: return 0.28
         case .sandstone, .limestone, .conglomerate: return 0.3
+        case .soapstone: return 0.3
+        case .serpentinite: return 0.4
         case .slate: return 0.4
+        case .phyllite: return 0.42
+        case .tuff: return 0.45
+        case .aetherstone: return 0.45
+        case .moonstone: return 0.48
+        case .glowstone: return 0.5
         case .schist: return 0.5
+        case .sunrock: return 0.52
+        case .crystalrock: return 0.55
         case .marble: return 0.55
+        case .livingrock: return 0.58
+        case .rhyolite: return 0.6
         case .andesite: return 0.6
+        case .runestone: return 0.6
         case .basalt: return 0.65
+        case .shadowrock: return 0.65
         case .diorite: return 0.7
+        case .pegmatite: return 0.7
+        case .bloodstone: return 0.7
         case .gneiss: return 0.75
+        case .migmatite: return 0.78
         case .granite: return 0.8
         case .gabbro: return 0.8
         case .quartzite: return 0.85
+        case .voidrock: return 0.85
+        case .dragonrock: return 0.88
         case .obsidian: return 0.9
+        case .deepslate: return 0.92
         }
     }
 
     /// Ore types that can appear within this rock
     var compatibleOres: [OreType] {
         switch self {
-        // Sedimentary: coal, iron, tin
-        case .sandstone, .limestone, .shale, .conglomerate:
-            return [.coal, .iron, .tin]
-        // Igneous extrusive: iron, copper
+        // Sedimentary: coal, iron, tin + new sedimentary ores
+        case .sandstone, .conglomerate:
+            return [.coal, .iron, .tin, .lead, .zinc]
+        case .limestone:
+            return [.coal, .iron, .tin, .lead, .zinc]
+        case .shale:
+            return [.coal, .iron, .tin, .lead, .bauxite]
+        case .chalk:
+            return [.coal, .saltpeter, .lead]
+        case .mudstone:
+            return [.coal, .iron, .bauxite]
+        case .siltstone:
+            return [.coal, .lead, .zinc]
+        case .travertine:
+            return [.saltpeter, .zinc]
+
+        // Igneous extrusive: iron, copper + new volcanic ores
         case .basalt, .andesite:
-            return [.iron, .copper]
-        // Igneous intrusive: tin, copper, gold, silver, gemstone
-        case .granite, .diorite, .gabbro:
+            return [.iron, .copper, .zinc, .nickel]
+        case .rhyolite:
+            return [.iron, .copper, .sulfur]
+        case .tuff:
+            return [.sulfur, .mercury]
+        case .pumice:
+            return [.sulfur]
+
+        // Igneous intrusive: tin, copper, gold, silver, gemstone + new deep ores
+        case .granite, .diorite:
             return [.tin, .copper, .gold, .silver, .gemstone]
-        // Metamorphic: gold, silver, gemstone
-        case .slate, .schist, .marble, .quartzite, .gneiss:
+        case .gabbro:
+            return [.tin, .copper, .gold, .silver, .gemstone, .chromium]
+        case .pegmatite:
+            return [.platinum, .bismuth, .gemstone, .tin]
+
+        // Metamorphic: gold, silver, gemstone + new metamorphic ores
+        case .slate, .schist, .quartzite, .gneiss:
             return [.gold, .silver, .gemstone]
-        // Obsidian: gemstone only
+        case .marble:
+            return [.gold, .silver, .gemstone]
+        case .serpentinite:
+            return [.chromium, .nickel, .cobalt]
+        case .soapstone:
+            return [.tungsten, .mithril]
+        case .phyllite:
+            return [.gold, .tungsten]
+        case .migmatite:
+            return [.platinum, .mithril]
+
+        // Volcanic glass
         case .obsidian:
-            return [.gemstone]
+            return [.gemstone, .mercury]
+
+        // Fantasy — deep crust
+        case .deepslate:
+            return [.adamantine, .starmetal]
+
+        // Fantasy — magical rocks
+        case .glowstone:
+            return [.moonsilver, .etherealite]
+        case .shadowrock:
+            return [.darksteel, .voidstone]
+        case .crystalrock:
+            return [.etherealite, .moonsilver]
+        case .bloodstone:
+            return [.bloodiron]
+        case .voidrock:
+            return [.voidstone, .adamantine]
+        case .moonstone:
+            return [.moonsilver, .mithril]
+        case .sunrock:
+            return [.sunstone, .orichalcum]
+        case .dragonrock:
+            return [.dragonite, .sunstone]
+        case .runestone:
+            return [.runegold, .mithril]
+        case .aetherstone:
+            return [.etherealite, .starmetal]
+        case .livingrock:
+            return [.mithril, .orichalcum]
         }
     }
 }

--- a/OutpostKit/Sources/OutpostWorldGen/Terrain/Geology/StrataGenerator.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Terrain/Geology/StrataGenerator.swift
@@ -97,65 +97,109 @@ struct StrataGenerator: Sendable {
     private static func layerSequence(for context: TectonicContext) -> [RockLayer] {
         switch context {
         case .stableContinental:
-            // Sediment field: sandstone → limestone → shale → gneiss → granite
+            // Sediment field with new soft rocks near surface, fantasy at depth
             return [
-                RockLayer(rockType: .sandstone, thickness: 0.20),
-                RockLayer(rockType: .limestone, thickness: 0.20),
-                RockLayer(rockType: .shale, thickness: 0.15),
-                RockLayer(rockType: .gneiss, thickness: 0.20),
-                RockLayer(rockType: .granite, thickness: 0.25),
+                RockLayer(rockType: .chalk, thickness: 0.08),
+                RockLayer(rockType: .sandstone, thickness: 0.14),
+                RockLayer(rockType: .limestone, thickness: 0.14),
+                RockLayer(rockType: .mudstone, thickness: 0.08),
+                RockLayer(rockType: .shale, thickness: 0.10),
+                RockLayer(rockType: .gneiss, thickness: 0.14),
+                RockLayer(rockType: .livingrock, thickness: 0.04),
+                RockLayer(rockType: .deepslate, thickness: 0.10),
+                RockLayer(rockType: .runestone, thickness: 0.03),
+                RockLayer(rockType: .aetherstone, thickness: 0.02),
+                RockLayer(rockType: .granite, thickness: 0.13),
             ]
 
         case .continentalCollision:
-            // High stress metamorphic: slate → schist → marble → granite
+            // High stress metamorphic with new metamorphic rocks
             return [
-                RockLayer(rockType: .slate, thickness: 0.20),
-                RockLayer(rockType: .schist, thickness: 0.25),
-                RockLayer(rockType: .marble, thickness: 0.25),
-                RockLayer(rockType: .granite, thickness: 0.30),
+                RockLayer(rockType: .phyllite, thickness: 0.10),
+                RockLayer(rockType: .slate, thickness: 0.14),
+                RockLayer(rockType: .schist, thickness: 0.14),
+                RockLayer(rockType: .serpentinite, thickness: 0.06),
+                RockLayer(rockType: .marble, thickness: 0.14),
+                RockLayer(rockType: .migmatite, thickness: 0.08),
+                RockLayer(rockType: .moonstone, thickness: 0.04),
+                RockLayer(rockType: .deepslate, thickness: 0.10),
+                RockLayer(rockType: .voidrock, thickness: 0.03),
+                RockLayer(rockType: .granite, thickness: 0.17),
             ]
 
         case .subductionZone:
-            // Volcanic arc: basalt → andesite → diorite → granite → schist
+            // Volcanic arc with new extrusive/intrusive rocks
             return [
-                RockLayer(rockType: .basalt, thickness: 0.15),
-                RockLayer(rockType: .andesite, thickness: 0.20),
-                RockLayer(rockType: .diorite, thickness: 0.20),
-                RockLayer(rockType: .granite, thickness: 0.25),
-                RockLayer(rockType: .schist, thickness: 0.20),
+                RockLayer(rockType: .tuff, thickness: 0.06),
+                RockLayer(rockType: .basalt, thickness: 0.10),
+                RockLayer(rockType: .rhyolite, thickness: 0.08),
+                RockLayer(rockType: .andesite, thickness: 0.12),
+                RockLayer(rockType: .diorite, thickness: 0.14),
+                RockLayer(rockType: .pegmatite, thickness: 0.06),
+                RockLayer(rockType: .sunrock, thickness: 0.04),
+                RockLayer(rockType: .dragonrock, thickness: 0.03),
+                RockLayer(rockType: .deepslate, thickness: 0.10),
+                RockLayer(rockType: .schist, thickness: 0.12),
+                RockLayer(rockType: .granite, thickness: 0.15),
             ]
 
         case .continentalRift:
-            // Rift fill: sandstone → basalt → granite
+            // Rift fill with siltstone and pumice, fantasy at depth
             return [
-                RockLayer(rockType: .sandstone, thickness: 0.30),
-                RockLayer(rockType: .basalt, thickness: 0.35),
-                RockLayer(rockType: .granite, thickness: 0.35),
+                RockLayer(rockType: .siltstone, thickness: 0.08),
+                RockLayer(rockType: .sandstone, thickness: 0.16),
+                RockLayer(rockType: .pumice, thickness: 0.06),
+                RockLayer(rockType: .basalt, thickness: 0.20),
+                RockLayer(rockType: .shadowrock, thickness: 0.04),
+                RockLayer(rockType: .crystalrock, thickness: 0.04),
+                RockLayer(rockType: .deepslate, thickness: 0.10),
+                RockLayer(rockType: .granite, thickness: 0.20),
+                RockLayer(rockType: .glowstone, thickness: 0.03),
+                RockLayer(rockType: .bloodstone, thickness: 0.03),
+                RockLayer(rockType: .deepslate, thickness: 0.06),
             ]
 
         case .oceanicSpread:
-            // Mid-ocean ridge: limestone → basalt → gabbro
+            // Mid-ocean ridge with tuff and soapstone
             return [
-                RockLayer(rockType: .limestone, thickness: 0.20),
-                RockLayer(rockType: .basalt, thickness: 0.40),
-                RockLayer(rockType: .gabbro, thickness: 0.40),
+                RockLayer(rockType: .travertine, thickness: 0.06),
+                RockLayer(rockType: .limestone, thickness: 0.12),
+                RockLayer(rockType: .tuff, thickness: 0.06),
+                RockLayer(rockType: .basalt, thickness: 0.26),
+                RockLayer(rockType: .soapstone, thickness: 0.04),
+                RockLayer(rockType: .gabbro, thickness: 0.26),
+                RockLayer(rockType: .deepslate, thickness: 0.08),
+                RockLayer(rockType: .aetherstone, thickness: 0.03),
+                RockLayer(rockType: .livingrock, thickness: 0.03),
+                RockLayer(rockType: .deepslate, thickness: 0.06),
             ]
 
         case .transformFault:
-            // Sheared strata: sandstone → slate → schist → granite
+            // Sheared strata with phyllite and serpentinite
             return [
-                RockLayer(rockType: .sandstone, thickness: 0.20),
-                RockLayer(rockType: .slate, thickness: 0.25),
-                RockLayer(rockType: .schist, thickness: 0.25),
-                RockLayer(rockType: .granite, thickness: 0.30),
+                RockLayer(rockType: .siltstone, thickness: 0.06),
+                RockLayer(rockType: .sandstone, thickness: 0.12),
+                RockLayer(rockType: .phyllite, thickness: 0.10),
+                RockLayer(rockType: .serpentinite, thickness: 0.08),
+                RockLayer(rockType: .slate, thickness: 0.14),
+                RockLayer(rockType: .schist, thickness: 0.14),
+                RockLayer(rockType: .runestone, thickness: 0.04),
+                RockLayer(rockType: .deepslate, thickness: 0.10),
+                RockLayer(rockType: .shadowrock, thickness: 0.03),
+                RockLayer(rockType: .granite, thickness: 0.19),
             ]
 
         case .stableOceanic:
-            // Ocean floor: limestone → basalt → gabbro
+            // Ocean floor with mudstone
             return [
-                RockLayer(rockType: .limestone, thickness: 0.15),
-                RockLayer(rockType: .basalt, thickness: 0.45),
-                RockLayer(rockType: .gabbro, thickness: 0.40),
+                RockLayer(rockType: .mudstone, thickness: 0.06),
+                RockLayer(rockType: .limestone, thickness: 0.10),
+                RockLayer(rockType: .basalt, thickness: 0.30),
+                RockLayer(rockType: .gabbro, thickness: 0.26),
+                RockLayer(rockType: .deepslate, thickness: 0.10),
+                RockLayer(rockType: .moonstone, thickness: 0.03),
+                RockLayer(rockType: .voidrock, thickness: 0.03),
+                RockLayer(rockType: .deepslate, thickness: 0.12),
             ]
         }
     }

--- a/OutpostKit/Sources/OutpostWorldGen/Terrain/WorldMapTypes.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Terrain/WorldMapTypes.swift
@@ -84,6 +84,7 @@ struct WorldMapCell: Sendable {
     var soilDepth: Float = 0.0       // 0-1
     var oreType: OreType? = nil
     var oreRichness: Float = 0.0     // 0-1
+    var gemstoneType: GemstoneType? = nil
 
     init() {}
 }

--- a/OutpostSim/Sources/OutpostSim/Renderer.swift
+++ b/OutpostSim/Sources/OutpostSim/Renderer.swift
@@ -138,17 +138,33 @@ public final class Renderer: Sendable {
             return "\(ANSI.green)*\(ANSI.reset)"
         case .wall:
             return "\(ANSI.white)#\(ANSI.reset)"
-        // Geological rock types
-        case .sandstone, .limestone:
+        // Geological rock types — sedimentary
+        case .sandstone, .limestone, .chalk, .mudstone, .siltstone, .travertine:
             return "\(ANSI.yellow)\(char)\(ANSI.reset)"
-        case .granite, .diorite, .quartzite:
+        // Igneous extrusive
+        case .rhyolite, .tuff, .pumice:
             return "\(ANSI.gray)\(char)\(ANSI.reset)"
-        case .basalt, .gabbro, .obsidian:
+        // Igneous intrusive
+        case .granite, .diorite, .quartzite, .pegmatite:
+            return "\(ANSI.gray)\(char)\(ANSI.reset)"
+        case .basalt, .gabbro, .obsidian, .deepslate:
             return "\(ANSI.dim)\(ANSI.gray)\(char)\(ANSI.reset)"
-        case .marble:
+        case .marble, .migmatite:
             return "\(ANSI.white)\(char)\(ANSI.reset)"
-        case .slate, .shale, .schist:
+        // Metamorphic
+        case .slate, .shale, .schist, .phyllite, .serpentinite, .soapstone:
             return "\(ANSI.gray)\(char)\(ANSI.reset)"
+        // Fantasy rocks — magical glow
+        case .glowstone, .crystalrock, .aetherstone, .moonstone:
+            return "\(ANSI.cyan)\(char)\(ANSI.reset)"
+        case .sunrock, .dragonrock:
+            return "\(ANSI.red)\(char)\(ANSI.reset)"
+        case .shadowrock, .voidrock:
+            return "\(ANSI.dim)\(ANSI.magenta)\(char)\(ANSI.reset)"
+        case .bloodstone:
+            return "\(ANSI.red)\(char)\(ANSI.reset)"
+        case .runestone, .livingrock:
+            return "\(ANSI.green)\(char)\(ANSI.reset)"
         default:
             return char
         }


### PR DESCRIPTION
## Summary
- Add **GemstoneType** enum (12 varieties: diamond, ruby, emerald, sapphire, amethyst, topaz, opal, garnet, jade, onyx, turquoise, lapis) with rarity and value properties, replacing the catch-all `.gemstone` OreType
- Add **24 new OreType** cases: 12 real geology (lead, zinc, nickel, platinum, chromium, tungsten, cobalt, mercury, sulfur, saltpeter, bauxite, bismuth) + 12 fantasy (mithril, adamantine, orichalcum, starmetal, moonsilver, sunstone, darksteel, bloodiron, etherealite, runegold, voidstone, dragonite)
- Add **24 new RockType** cases: 12 real geology (chalk, mudstone, siltstone, travertine, rhyolite, tuff, pumice, pegmatite, serpentinite, soapstone, phyllite, migmatite) + 12 fantasy (deepslate, glowstone, shadowrock, crystalrock, bloodstone, voidrock, moonstone, sunrock, dragonrock, runestone, aetherstone, livingrock)
- Add **24 new TerrainType** cases with displayChar, isPassable, isMinable, and movementCost properties
- Update StrataGenerator layer sequences to integrate new rocks at geologically appropriate depths (fantasy rocks at depth)
- Update DetailPass to select specific GemstoneType from rock compatibility when placing gemstone ore
- Update World.mineTile with new rocks categorized into standard/finelyCrafted/masterwork quality groups
- Add placeholder texture colors (TextureManager) and ANSI color groups (Renderer) for all 24 new terrain types

## Test plan
- [x] `cd OutpostKit && swift build` — compiles cleanly
- [x] `cd OutpostKit && swift test` — all 65 tests pass
- [x] `cd OutpostSim && swift build && swift run OutpostSim -t 100` — E2E smoke test passes
- [x] `xcodebuild -scheme Outpost -destination 'platform=macOS' build` — Outpost app builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)