### PR TITLE
Add TerrainStage protocol for composable terrain pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,16 +11,10 @@
     - `Config/` — YAML config loading (`ConfigurationLoader`, registries)
     - `Resources/` — Default YAML configs (`outpost.yaml`, `creatures.yaml`, `items.yaml`)
   - `Sources/OutpostWorldGen/` — World generation module (Layer 2 — depends on OutpostCore)
-    - `Pipeline/` — Orchestration: `WorldMapGenerator`, `WorldMapTypes`, `LocalTerrainGenerator`
+    - `Pipeline/` — Orchestration: `WorldMapGenerator`, `WorldMapTypes`, `LocalTerrainGenerator`, `TerrainStage` (protocol + `WorldGenContext`), `TerrainPipeline` (composable orchestrator + `CompositeTerrainStage`)
     - `Noise/` — Shared infrastructure: `SeededRNG`, `SimplexNoise`, `NoiseUtilities`
-    - `Tectonics/` — Stage 1: `TectonicSimulator`, `GeologyGenerator`, `StrataGenerator`
-    - `Heightmap/` — Stage 2: `HeightmapGenerator`
-    - `Erosion/` — Stage 3: `ErosionSimulator`
-    - `Climate/` — Stage 4: `ClimateSimulator`
-    - `Hydrology/` — Stage 5: `HydrologySimulator`
-    - `Biomes/` — Stage 6: `BiomeClassifier`
-    - `Detail/` — Stage 7: `DetailPass`
-    - `Metal/` — GPU acceleration: `TerrainShaders.metal`, `MetalTerrainAccelerator.swift`
+    - `Generators/` — Pipeline stages 1–7: `TectonicSimulator`, `GeologyGenerator`, `StrataGenerator`, `HeightmapGenerator`, `ErosionSimulator`, `ClimateSimulator`, `HydrologySimulator`, `BiomeClassifier`, `DetailPass` (each conforms to `TerrainStage`)
+    - `Metal/` — GPU acceleration: `TerrainShaders.metal`, `MetalTerrainAccelerator.swift`, `MetalTerrainStages.swift` (`MetalHeightmapStage`, `MetalClimateStage`)
     - `WorldGenerator.swift` — World generator with history simulation (produces unified `World` struct)
   - `Sources/OutpostRuntime/` — Simulation engine and manager systems (Layer 3 — depends on OutpostCore + OutpostWorldGen)
     - `Simulation.swift` — Core simulation orchestrator

--- a/OutpostKit/Sources/OutpostWorldGen/Generators/BiomeClassifier.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Generators/BiomeClassifier.swift
@@ -186,3 +186,17 @@ struct BiomeClassifier: Sendable {
         return .tropicalRainforest
     }
 }
+
+// MARK: - TerrainStage Conformance
+
+extension BiomeClassifier: TerrainStage {
+    var forkLabel: String { "biome" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Classifying biomes..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        Self.classify(map: &map)
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Generators/ClimateSimulator.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Generators/ClimateSimulator.swift
@@ -190,3 +190,17 @@ struct ClimateSimulator: Sendable {
         }
     }
 }
+
+// MARK: - TerrainStage Conformance
+
+extension ClimateSimulator: TerrainStage {
+    var forkLabel: String { "climate" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Simulating climate..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        Self.simulate(map: &map, noise: context.noise, rng: &rng)
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Generators/DetailPass.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Generators/DetailPass.swift
@@ -205,3 +205,17 @@ struct DetailPass: Sendable {
         cell.oreRichness = richness
     }
 }
+
+// MARK: - TerrainStage Conformance
+
+extension DetailPass: TerrainStage {
+    var forkLabel: String { "detail" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Adding vegetation and ore deposits..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        Self.apply(map: &map, noise: context.noise, rng: &rng)
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Generators/ErosionSimulator.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Generators/ErosionSimulator.swift
@@ -279,3 +279,17 @@ struct ErosionSimulator: Sendable {
         }
     }
 }
+
+// MARK: - TerrainStage Conformance
+
+extension ErosionSimulator: TerrainStage {
+    var forkLabel: String { "erosion" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Simulating erosion (\(context.params.erosionDroplets) droplets)..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        Self.simulate(map: &map, params: context.params, rng: &rng)
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Generators/GeologyGenerator.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Generators/GeologyGenerator.swift
@@ -40,3 +40,17 @@ struct GeologyGenerator: Sendable {
         }
     }
 }
+
+// MARK: - TerrainStage Conformance
+
+extension GeologyGenerator: TerrainStage {
+    var forkLabel: String { "geology" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Generating geological strata..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        Self.generate(map: &map, noise: context.noise, rng: &rng)
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Generators/HeightmapGenerator.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Generators/HeightmapGenerator.swift
@@ -129,3 +129,17 @@ struct HeightmapGenerator: Sendable {
         }
     }
 }
+
+// MARK: - TerrainStage Conformance
+
+extension HeightmapGenerator: TerrainStage {
+    var forkLabel: String { "heightmap" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Generating heightmap..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        Self.generate(map: &map, noise: context.noise, rng: &rng)
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Generators/HydrologySimulator.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Generators/HydrologySimulator.swift
@@ -340,3 +340,17 @@ struct HydrologySimulator: Sendable {
         }
     }
 }
+
+// MARK: - TerrainStage Conformance
+
+extension HydrologySimulator: TerrainStage {
+    var forkLabel: String { "hydrology" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Tracing rivers and lakes..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        Self.simulate(map: &map, rng: &rng)
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Generators/TectonicSimulator.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Generators/TectonicSimulator.swift
@@ -215,3 +215,17 @@ struct TectonicSimulator: Sendable {
         }
     }
 }
+
+// MARK: - TerrainStage Conformance
+
+extension TectonicSimulator: TerrainStage {
+    var forkLabel: String { "tectonic" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Simulating tectonic plates..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        Self.simulate(map: &map, params: context.params, rng: &rng)
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Metal/MetalTerrainStages.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Metal/MetalTerrainStages.swift
@@ -1,0 +1,41 @@
+// MARK: - Metal GPU Terrain Stages
+// TerrainStage wrappers for GPU-accelerated heightmap and climate generation
+
+#if canImport(Metal)
+
+import OutpostCore
+
+/// GPU-accelerated heightmap generation stage.
+/// Uses `MetalTerrainAccelerator.generateHeightmap()` for the heavy lifting.
+/// Shares the same `forkLabel` as `HeightmapGenerator` for deterministic RNG parity.
+struct MetalHeightmapStage: TerrainStage {
+    let accelerator: MetalTerrainAccelerator
+    var forkLabel: String { "heightmap" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Generating heightmap (GPU)..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        accelerator.generateHeightmap(map: &map, noise: context.noise)
+    }
+}
+
+/// GPU-accelerated climate stage.
+/// Runs temperature and wind on the GPU, then moisture advection on the CPU.
+/// Shares the same `forkLabel` as `ClimateSimulator` for deterministic RNG parity.
+struct MetalClimateStage: TerrainStage {
+    let accelerator: MetalTerrainAccelerator
+    var forkLabel: String { "climate" }
+
+    func progressMessage(context: WorldGenContext) -> String {
+        "Simulating climate (GPU)..."
+    }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        accelerator.generateTemperatureAndWind(map: &map, noise: context.noise)
+        ClimateSimulator.applyMoistureAdvection(map: &map, noise: context.noise, rng: &rng)
+    }
+}
+
+#endif

--- a/OutpostKit/Sources/OutpostWorldGen/Pipeline/TerrainPipeline.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Pipeline/TerrainPipeline.swift
@@ -1,0 +1,112 @@
+// MARK: - Terrain Pipeline
+// Composable orchestrator that runs an ordered list of TerrainStage instances
+
+import OutpostCore
+
+/// A composite stage that groups multiple sub-stages into a single logical step.
+struct CompositeTerrainStage: TerrainStage {
+    let forkLabel: String
+    private let message: String
+    let stages: [any TerrainStage]
+
+    init(forkLabel: String, message: String, stages: [any TerrainStage]) {
+        self.forkLabel = forkLabel
+        self.message = message
+        self.stages = stages
+    }
+
+    func progressMessage(context: WorldGenContext) -> String { message }
+
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext) {
+        for stage in stages {
+            var stageRNG = rng.fork(stage.forkLabel)
+            stage.run(map: &map, rng: &stageRNG, context: context)
+        }
+    }
+}
+
+/// An ordered sequence of terrain stages executed with deterministic RNG forking.
+struct TerrainPipeline: Sendable {
+    let stages: [any TerrainStage]
+
+    /// Builds the default 8-stage pipeline, selecting GPU stages when available.
+    static func defaultPipeline() -> TerrainPipeline {
+        var stages: [any TerrainStage] = []
+
+        stages.append(TectonicSimulator())
+
+        #if canImport(Metal)
+        if let accel = MetalTerrainAccelerator() {
+            stages.append(MetalHeightmapStage(accelerator: accel))
+        } else {
+            stages.append(HeightmapGenerator())
+        }
+        #else
+        stages.append(HeightmapGenerator())
+        #endif
+
+        stages.append(ErosionSimulator())
+        stages.append(GeologyGenerator())
+
+        #if canImport(Metal)
+        if let accel = MetalTerrainAccelerator() {
+            stages.append(MetalClimateStage(accelerator: accel))
+        } else {
+            stages.append(ClimateSimulator())
+        }
+        #else
+        stages.append(ClimateSimulator())
+        #endif
+
+        stages.append(HydrologySimulator())
+        stages.append(BiomeClassifier())
+        stages.append(DetailPass())
+
+        return TerrainPipeline(stages: stages)
+    }
+
+    /// Builds the CPU-only pipeline (no Metal acceleration).
+    static func cpuPipeline() -> TerrainPipeline {
+        TerrainPipeline(stages: [
+            TectonicSimulator(),
+            HeightmapGenerator(),
+            ErosionSimulator(),
+            GeologyGenerator(),
+            ClimateSimulator(),
+            HydrologySimulator(),
+            BiomeClassifier(),
+            DetailPass(),
+        ])
+    }
+
+    /// Execute all stages in order, forking the RNG for each stage.
+    /// - Parameters:
+    ///   - context: Shared generation context (params + noise)
+    ///   - rng: Root RNG — each stage receives an independent fork
+    ///   - progress: Optional callback invoked before each stage
+    /// - Returns: The generated world map
+    func run(
+        context: WorldGenContext,
+        rng: SeededRNG,
+        progress: ((String) -> Void)? = nil
+    ) -> WorldMap {
+        var map = WorldMap(size: context.params.mapSize, seed: context.params.seed)
+        run(into: &map, context: context, rng: rng, progress: progress)
+        return map
+    }
+
+    /// Execute all stages into an existing map.
+    func run(
+        into map: inout WorldMap,
+        context: WorldGenContext,
+        rng: SeededRNG,
+        progress: ((String) -> Void)? = nil
+    ) {
+        for stage in stages {
+            progress?(stage.progressMessage(context: context))
+            var stageRNG = rng.fork(stage.forkLabel)
+            stage.run(map: &map, rng: &stageRNG, context: context)
+        }
+        progress?("World map generation complete.")
+    }
+}

--- a/OutpostKit/Sources/OutpostWorldGen/Pipeline/TerrainStage.swift
+++ b/OutpostKit/Sources/OutpostWorldGen/Pipeline/TerrainStage.swift
@@ -1,0 +1,31 @@
+// MARK: - Terrain Stage Protocol
+// Composable pipeline stage for terrain generation
+
+import OutpostCore
+
+/// Immutable context shared across all terrain stages
+struct WorldGenContext: Sendable {
+    let params: WorldGenParameters
+    let noise: SimplexNoise
+}
+
+/// A single composable step in the terrain generation pipeline.
+///
+/// Each stage receives a forked RNG (independent from the root), so reordering
+/// stages does not break determinism. The `forkLabel` is hashed via FNV-1a in
+/// `SeededRNG.fork(_:)` to produce the child seed.
+protocol TerrainStage: Sendable {
+    /// Stable identifier used to fork a deterministic child RNG.
+    /// Must never change between versions for a given stage.
+    var forkLabel: String { get }
+
+    /// Human-readable progress message for this stage.
+    func progressMessage(context: WorldGenContext) -> String
+
+    /// Execute the stage, mutating the world map in place.
+    /// - Parameters:
+    ///   - map: The world map to modify
+    ///   - rng: A forked RNG specific to this stage
+    ///   - context: Shared generation parameters and noise
+    func run(map: inout WorldMap, rng: inout SeededRNG, context: WorldGenContext)
+}


### PR DESCRIPTION
## Summary
- Introduces a `TerrainStage` protocol that all 8 terrain generators conform to, enabling composable and customizable pipelines
- Replaces hardcoded stage sequences in `WorldMapGenerator.generate()` and `WorldGenerator.phaseProceduralTerrain()` with a `TerrainPipeline` orchestrator
- Adds GPU-accelerated stage wrappers (`MetalHeightmapStage`, `MetalClimateStage`) behind `#if canImport(Metal)` with automatic fallback to CPU stages

## New types
| Type | File | Purpose |
|------|------|---------|
| `TerrainStage` | `Pipeline/TerrainStage.swift` | Protocol: `forkLabel`, `progressMessage`, `run` |
| `WorldGenContext` | `Pipeline/TerrainStage.swift` | Immutable context (params + noise) |
| `TerrainPipeline` | `Pipeline/TerrainPipeline.swift` | Ordered stage list with `defaultPipeline()` / `cpuPipeline()` |
| `CompositeTerrainStage` | `Pipeline/TerrainPipeline.swift` | Groups sub-stages into a single logical step |
| `MetalHeightmapStage` | `Metal/MetalTerrainStages.swift` | GPU heightmap wrapper |
| `MetalClimateStage` | `Metal/MetalTerrainStages.swift` | GPU climate wrapper |

## Design decisions
- Each stage's `forkLabel` is position-independent — reordering stages doesn't break determinism
- `WorldMapGenerator.generate()` now accepts an optional `pipeline:` parameter for custom pipelines
- Existing static methods on generators are preserved; conformance extensions delegate to them
- GPU stages share the same `forkLabel` as their CPU counterparts for RNG parity

## Test plan
- [x] `swift build` (OutpostKit)
- [x] `swift test` (65 tests pass)
- [x] `swift build` (OutpostSim)
- [x] `xcodebuild` (Outpost macOS app)
- [x] E2E smoke test via `OutpostSim -t 100 --turbo --headless`

🤖 Generated with [Claude Code](https://claude.com/claude-code)